### PR TITLE
Fix harvester configs

### DIFF
--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/airScoopExV/airScoopExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/airScoopExV/airScoopExL.cfg
@@ -35,9 +35,8 @@ PART
 		Efficiency = 0.248
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0031
 		intakeSpeed = 15
 		airSpeedStatic = 15
@@ -65,15 +64,5 @@ PART
 	{
 		model = Squad/Parts/Aero/airIntakeRadialXM-G50/RadialIntake
 		texture = RadialIntake, ExplodiumBreathingEngines/Parts/Aero/airScoopExV/RadialIntakeExL
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/airScoopExV/airScoopExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/airScoopExV/airScoopExV.cfg
@@ -35,9 +35,8 @@ PART
 		Efficiency = 0.248
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0031
 		intakeSpeed = 15
 		airSpeedStatic = 15
@@ -65,15 +64,5 @@ PART
 	{
 		model = Squad/Parts/Aero/airIntakeRadialXM-G50/RadialIntake
 		texture = RadialIntake, ExplodiumBreathingEngines/Parts/Aero/airScoopExV/RadialIntakeExV
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/CircularIntakeExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/CircularIntakeExL.cfg
@@ -47,9 +47,8 @@ PART
 		Efficiency = 0.479
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		airSpeedStatic = 15
 		intakeTransformName = Intake
 		machCurve
@@ -75,16 +74,6 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = IntakeCircularHeat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }
 

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/CircularIntakeExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/CircularIntakeExV.cfg
@@ -47,9 +47,8 @@ PART
 		Efficiency = 0.479
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		airSpeedStatic = 15
 		intakeTransformName = Intake
 		machCurve
@@ -75,16 +74,6 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = IntakeCircularHeat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }
 

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/shockConeIntakeExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/shockConeIntakeExL.cfg
@@ -45,9 +45,8 @@ PART
 		Efficiency = 0.599
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0075
 		intakeSpeed = 5
 		airSpeedStatic = 5
@@ -78,16 +77,6 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = IntakeConeHeat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = Open Duct
-		retractActionName = Close Duct
-		toggleActionName = Toggle Duct
-		moduleType = Duct
 	}
 }
 

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/shockConeIntakeExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/circularIntakeExV/shockConeIntakeExV.cfg
@@ -45,9 +45,8 @@ PART
 		Efficiency = 0.599
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0075
 		intakeSpeed = 5
 		airSpeedStatic = 5
@@ -78,16 +77,6 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = IntakeConeHeat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }
 

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/intakeRadialLongExV/IntakeRadialLongExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/intakeRadialLongExV/IntakeRadialLongExL.cfg
@@ -40,9 +40,8 @@ PART
 		Efficiency = 0.068
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.001
 		intakeSpeed = 10
 		airSpeedStatic = 10
@@ -66,15 +65,5 @@ PART
 		name = ExpVapourLite
 		amount = 0.05
 		maxAmount = 0.05
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/intakeRadialLongExV/IntakeRadialLongExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/intakeRadialLongExV/IntakeRadialLongExV.cfg
@@ -40,9 +40,8 @@ PART
 		Efficiency = 0.068
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.001
 		intakeSpeed = 10
 		airSpeedStatic = 10
@@ -66,15 +65,5 @@ PART
 		name = ExpVapour
 		amount = 0.05
 		maxAmount = 0.05
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/miniIntakeExV/miniIntakeExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/miniIntakeExV/miniIntakeExL.cfg
@@ -38,9 +38,8 @@ PART
 		Efficiency = 0.080
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.001
 		intakeSpeed = 15
 		airSpeedStatic = 15
@@ -68,16 +67,6 @@ PART
 	{
 		model = Squad/Parts/Aero/miniIntake/SmallIntake
 		texture = SmallIntake, ExplodiumBreathingEngines/Parts/Aero/miniIntakeExV/miniIntakeExL
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = Open Duct
-		retractActionName = Close Duct
-		toggleActionName = Toggle Duct
-		moduleType = Duct
 	}
 }
 

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/miniIntakeExV/miniIntakeExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/miniIntakeExV/miniIntakeExV.cfg
@@ -38,9 +38,8 @@ PART
 		Efficiency = 0.080
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.001
 		intakeSpeed = 15
 		airSpeedStatic = 15
@@ -68,16 +67,6 @@ PART
 	{
 		model = Squad/Parts/Aero/miniIntake/SmallIntake
 		texture = SmallIntake, ExplodiumBreathingEngines/Parts/Aero/miniIntakeExV/miniIntakeExV
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }
 

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/ramAirIntakeExV/ramAirIntakeExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/ramAirIntakeExV/ramAirIntakeExL.cfg
@@ -39,9 +39,8 @@ PART
 		Efficiency = 0.515
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0074
 		intakeSpeed = 10
 		airSpeedStatic = 10
@@ -75,15 +74,5 @@ PART
 	{
 		model = Squad/Parts/Aero/ramAirIntake/RampIntake
 		texture = RampIntake, ExplodiumBreathingEngines/Parts/Aero/ramAirIntakeExV/RampIntakeExL
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Aero/ramAirIntakeExV/ramAirIntakeExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Aero/ramAirIntakeExV/ramAirIntakeExV.cfg
@@ -39,9 +39,8 @@ PART
 		Efficiency = 0.515
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0074
 		intakeSpeed = 10
 		airSpeedStatic = 10
@@ -75,15 +74,5 @@ PART
 	{
 		model = Squad/Parts/Aero/ramAirIntake/RampIntake
 		texture = RampIntake, ExplodiumBreathingEngines/Parts/Aero/ramAirIntakeExV/RampIntakeExV
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Engine/jetEnginesOx/turboFanSize2Ox.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Engine/jetEnginesOx/turboFanSize2Ox.cfg
@@ -38,9 +38,8 @@ PART
 		Efficiency = 2.400
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.03
 		intakeSpeed = 30
 		airSpeedStatic = 30
@@ -429,15 +428,5 @@ PART
 				loop = false
 			}
 		}
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Engine/jetEnginesOx/turboFanSize2OxL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Engine/jetEnginesOx/turboFanSize2OxL.cfg
@@ -38,9 +38,8 @@ PART
 		Efficiency = 2.400
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.03
 		intakeSpeed = 30
 		airSpeedStatic = 30
@@ -429,15 +428,5 @@ PART
 				loop = false
 			}
 		}
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = Open Duct
-		retractActionName = Close Duct
-		toggleActionName = Toggle Duct
-		moduleType = Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/MK1IntakeFuselageExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/MK1IntakeFuselageExL.cfg
@@ -41,9 +41,8 @@ PART
 		Efficiency = 0.440
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0061
 		intakeSpeed = 12
 		airSpeedStatic = 12
@@ -78,15 +77,5 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = IntakeFuselageHeat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/MK1IntakeFuselageExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/MK1IntakeFuselageExV.cfg
@@ -41,9 +41,8 @@ PART
 		Efficiency = 0.440
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.0061
 		intakeSpeed = 12
 		airSpeedStatic = 12
@@ -78,15 +77,5 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = IntakeFuselageHeat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/nacelleBodyExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/nacelleBodyExL.cfg
@@ -40,9 +40,8 @@ PART
 		Efficiency = 0.400
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.005
 		intakeSpeed = 40
 		AirSpeedStatic = 40
@@ -76,15 +75,5 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = Nacelle1Heat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/nacelleBodyExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/nacelleBodyExV.cfg
@@ -40,9 +40,8 @@ PART
 		Efficiency = 0.400
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.005
 		intakeSpeed = 40
 		AirSpeedStatic = 40
@@ -76,15 +75,5 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = Nacelle1Heat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/radialEngineBodyExL.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/radialEngineBodyExL.cfg
@@ -42,9 +42,8 @@ PART
 		Efficiency = 0.292
 		ResourceName = ExpVapourLite
 		ConverterName = #exvLOC_503045 //ExL Filter
-		StartActionName = #exvLOC_503027 //Start ExL Filter
-		StopActionName = #exvLOC_503028 //Stop ExL Filter
-		ToggleActionName = #exvLOC_503029 //Toggle ExL Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.005
 		intakeSpeed = 30
 		AirSpeedStatic = 30
@@ -79,15 +78,5 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = Nacelle2Heat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }

--- a/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/radialEngineBodyExV.cfg
+++ b/GameData/ExplodiumBreathingEngines/Parts/Structural/mk1parts/radialEngineBodyExV.cfg
@@ -42,9 +42,8 @@ PART
 		Efficiency = 0.292
 		ResourceName = ExpVapour
 		ConverterName = #exvLOC_502045 //ExV Filter
-		StartActionName = #exvLOC_502027 //Start ExV Filter
-		StopActionName = #exvLOC_502028 //Stop ExV Filter
-		ToggleActionName = #exvLOC_502029 //Toggle ExV Filter
+		IsActivated = true
+		AlwaysActive = true
 		area = 0.005
 		intakeSpeed = 30
 		AirSpeedStatic = 30
@@ -79,15 +78,5 @@ PART
 	{
 		name = ModuleAnimateHeat
 		ThermalAnim = Nacelle2Heat
-	}
-	MODULE
-	{
-		name = ModuleAnimationGroup
-		deployAnimationName = 
-		activeAnimationName = 
-		deployActionName = #exvLOC_6002390 //Open <<1>>
-		retractActionName = #exvLOC_6002391 //Close <<1>>
-		toggleActionName = #exvLOC_6002392 //Toggle <<1>>
-		moduleType = #exvLOC_7001228 //Duct
 	}
 }


### PR DESCRIPTION
Set harvesters to always active to ensure they don't require activation on situation change and on spawn. An uninteractable toggle button in PAW remains(limitation of stock module), but harvester is active regardless.